### PR TITLE
fix: correct 'occured' to 'occurred' typo in xosint (×5)

### DIFF
--- a/xosint
+++ b/xosint
@@ -1613,7 +1613,7 @@ elif option == "15":
 			except ConnectionRefusedError:
 				print("{} Connection refused by host {}. It don't seem to be vunlerable to mail spoofing on port {} \033[0;37m \n".format(BLUE,target,port))
 			except Exception:
-				print("{} Exception Occured on host {}. It don't seem to be vunlerable to mail spoofing on port {} \033[0;37m \n".format(BLUE,target,port))
+				print("{} Exception occurred on host {}. It don't seem to be vunlerable to mail spoofing on port {} \033[0;37m \n".format(BLUE,target,port))
 			except KeyboardInterrupt:
 				print("Stopping...")
 				exit()
@@ -1634,7 +1634,7 @@ elif option == "15":
 			else:
 				print("{} The SMTP Server Targeted: {} don't seem to be vulberable to user enumeration on port {}. VRFY query responded statys : {}  \033[0;37m \n".format(BLUE,target,port,verify[0]))
 		except Exception:
-			print("{} Exception Occured on host {}. It don't seem to be vunlerable to user enumeration on port {}. \033[0;37m \n".format(BLUE,target,port))
+			print("{} Exception occurred on host {}. It don't seem to be vunlerable to user enumeration on port {}. \033[0;37m \n".format(BLUE,target,port))
 		except KeyboardInterrupt:
 			print("Stopping...")
 			exit()
@@ -1678,7 +1678,7 @@ elif option == "16":
                 return data
             
             except requests.exceptions.RequestException as e:
-                print(f"[!] An Error Occured: {e}")
+                print(f"[!] An Error occurred: {e}")
                 return None
             
         result = search_by_email(email_answer) # type: ignore
@@ -1702,7 +1702,7 @@ elif option == "16":
                 data = response.json()
                 return data
             except requests.exceptions.RequestException as e:
-                print(f"[!] An Error Occured: {e}")
+                print(f"[!] An Error occurred: {e}")
                 return None
         
         result2 = search_by_domain(domain_answer)
@@ -1727,7 +1727,7 @@ elif option == "16":
                 data = response.json()
                 return data
             except requests.exceptions.RequestException as e:
-                print(f"[!] An Error Occured: {e}")
+                print(f"[!] An Error occurred: {e}")
                 return None
         
         result3 = search_by_domain(username_answer)


### PR DESCRIPTION
## Summary
Correct spelling error `occured` → `occurred` in 5 user-facing print error messages.

## Changes
- Line 1616: `Exception Occured on host` → `Exception occurred on host`
- Line 1637: `Exception Occured on host` → `Exception occurred on host`
- Line 1681: `An Error Occured` → `An Error occurred`
- Line 1705: `An Error Occured` → `An Error occurred`
- Line 1730: `An Error Occured` → `An Error occurred`

All instances are in user-facing print statements for error/exception reporting.

## Testing
- `python3 -m py_compile xosint` ✅ (no syntax errors)
- Diff verified: 5 lines changed, only typo corrections

## Meta
- Author: Jah-yee <jydu_seven@outlook.com>
- Commits: 1 (single commit, squash-friendly)
- Email: 166608075+Jah-yee@users.noreply.github.com (GH007 compliant)
- Gate-1 ✅ (new fix) | Gate-2 ✅ (1 OPEN < 2) | Gate-3 ✅ (1 commit)